### PR TITLE
Performance improvement

### DIFF
--- a/MMGridView/Classes/MMGridView.m
+++ b/MMGridView/Classes/MMGridView.m
@@ -76,7 +76,40 @@
 
 - (void)layoutSubviews
 {
-    [self reloadData];
+    if (self.dataSource && self.numberOfRows > 0 && self.numberOfColumns > 0) {
+        NSInteger noOfCols = self.numberOfColumns;
+        NSInteger noOfRows = self.numberOfRows;
+        NSUInteger cellsPerPage = self.numberOfColumns * self.numberOfRows;
+        
+        BOOL isLandscape = UIInterfaceOrientationIsLandscape([[UIDevice currentDevice] orientation]);
+        if (isLandscape) {
+            // In landscape mode switch rows and columns
+            noOfCols = self.numberOfRows;
+            noOfRows = self.numberOfColumns;
+        }
+        
+        CGRect gridBounds = self.scrollView.bounds;
+        CGRect cellBounds = CGRectMake(0, 0, gridBounds.size.width / (float)noOfCols, 
+                                       gridBounds.size.height / (float)noOfRows);
+        
+        CGSize contentSize = CGSizeMake(self.numberOfPages * gridBounds.size.width, gridBounds.size.height);
+        [self.scrollView setContentSize:contentSize];
+        
+        for (NSInteger i = 0; i < [self.dataSource numberOfCellsInGridView:self]; i++) {
+            MMGridViewCell *cell = [self.dataSource gridView:self cellAtIndex:i];
+
+            NSInteger page = (int)floor((float)i / (float)cellsPerPage);
+            NSInteger row  = (int)floor((float)i / (float)noOfCols) - (page * noOfRows);
+            
+            CGPoint origin = CGPointMake((page * gridBounds.size.width) + ((i % noOfCols) * cellBounds.size.width), 
+                                         (row * cellBounds.size.height));
+            
+            CGRect f = CGRectMake(origin.x, origin.y, cellBounds.size.width, cellBounds.size.height);
+            cell.frame = CGRectInset(f, self.cellMargin, self.cellMargin);
+            
+            [self.scrollView addSubview:cell];
+        }
+    }
 }
 
 
@@ -148,43 +181,16 @@
         [v removeFromSuperview];
     }
     
-    if (self.dataSource && self.numberOfRows > 0 && self.numberOfColumns > 0) {
-        NSInteger noOfCols = self.numberOfColumns;
-        NSInteger noOfRows = self.numberOfRows;
-        NSUInteger cellsPerPage = self.numberOfColumns * self.numberOfRows;
-        
-        BOOL isLandscape = UIInterfaceOrientationIsLandscape([[UIDevice currentDevice] orientation]);
-        if (isLandscape) {
-            // In landscape mode switch rows and columns
-            noOfCols = self.numberOfRows;
-            noOfRows = self.numberOfColumns;
-        }
-        
-        CGRect gridBounds = self.scrollView.bounds;
-        CGRect cellBounds = CGRectMake(0, 0, gridBounds.size.width / (float)noOfCols, 
-                                       gridBounds.size.height / (float)noOfRows);
-        
-        CGSize contentSize = CGSizeMake(self.numberOfPages * gridBounds.size.width, gridBounds.size.height);
-        [self.scrollView setContentSize:contentSize];
-        
+    if (self.dataSource && self.numberOfRows > 0 && self.numberOfColumns > 0) {       
         for (NSInteger i = 0; i < [self.dataSource numberOfCellsInGridView:self]; i++) {
             MMGridViewCell *cell = [self.dataSource gridView:self cellAtIndex:i];
             [cell performSelector:@selector(setGridView:) withObject:self];
             [cell performSelector:@selector(setIndex:) withObject:[NSNumber numberWithInt:i]];
-            
-            
-            NSInteger page = (int)floor((float)i / (float)cellsPerPage);
-            NSInteger row  = (int)floor((float)i / (float)noOfCols) - (page * noOfRows);
-            
-            CGPoint origin = CGPointMake((page * gridBounds.size.width) + ((i % noOfCols) * cellBounds.size.width), 
-                                         (row * cellBounds.size.height));
-            
-            CGRect f = CGRectMake(origin.x, origin.y, cellBounds.size.width, cellBounds.size.height);
-            cell.frame = CGRectInset(f, self.cellMargin, self.cellMargin);
-            
             [self.scrollView addSubview:cell];
         }
     }
+
+    [self setNeedsLayout];
 }
 
 

--- a/MMGridView/Classes/MMGridView.m
+++ b/MMGridView/Classes/MMGridView.m
@@ -124,7 +124,7 @@
     self.contentMode = UIViewContentModeRedraw;
     self.backgroundColor = [UIColor clearColor];
     
-    self.scrollView = [[UIScrollView alloc] initWithFrame:self.bounds];
+    self.scrollView = [[[UIScrollView alloc] initWithFrame:self.bounds] autorelease];
     self.scrollView.delegate = self;
     self.scrollView.backgroundColor = [UIColor clearColor];
     self.scrollView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;


### PR DESCRIPTION
Hi,

When I testing on an older iPod, i notice the scrolling performance on a larger list is slower than it should be. 

I found that when the grid is scrolling, Core Animation will calls [MMGridView layoutSubviews] repeatly, which in turns call [MMGridView reloadData], which will remove all subviews and add all subviews again. 

This patch try to separate layoutSubviews and reloadData: layoutSubviews only layout, and reloadData will handle creation of subviews. This improve the performance of my apps from 7fps to 50 fps on scrolling.
