### PR TITLE
Add property to control layout direction

### DIFF
--- a/MMGridView/Classes/MMGridView.h
+++ b/MMGridView/Classes/MMGridView.h
@@ -25,6 +25,11 @@
 
 @class MMGridView;
 
+typedef enum
+{
+    MMGridViewLayoutDirectionHorizontal,
+    MMGridViewLayoutDirectionVertical
+} MMGridViewLayoutDirection;
 // ----------------------------------------------------------------------------------
 
 #pragma - MMGridViewDataSource
@@ -67,6 +72,7 @@
 @property (nonatomic, readonly) NSUInteger currentPageIndex;
 @property (nonatomic, readonly) NSUInteger numberOfPages;
 @property (nonatomic, assign, getter = isPagingEnabled) BOOL pagingEnabled;
+@property (nonatomic, assign) MMGridViewLayoutDirection layoutDirection;
 - (void)reloadData;
 
 @end


### PR DESCRIPTION
Added a property to control layout direction. It can be _MMGridViewLayoutDirctionHorizontal_ which is the default one and will layout pages beside each other horizontally. Another value is _MMGridViewLayoutDirctionVertical_ which will layout pages below each other vertically.
